### PR TITLE
Make sure net mode does not change total amount

### DIFF
--- a/engine/Shopware/Core/sBasket.php
+++ b/engine/Shopware/Core/sBasket.php
@@ -1196,7 +1196,7 @@ class sBasket
                 } else {
                     $p = floatval($this->moduleManager->Articles()->sRound(
                         $this->moduleManager->Articles()->sRound(
-                            $value["netprice"] * $value["quantity"])
+                            round($value["netprice"], 2) * $value["quantity"])
                         )
                     );
                 }
@@ -2247,7 +2247,7 @@ class sBasket
                 if (empty($getArticles[$key]["modus"])) {
                     $priceWithTax = round($netprice, 2) / 100 * (100 + $tax);
 
-                    $getArticles[$key]["amountWithTax"] = $quantity * $priceWithTax;
+                    $getArticles[$key]["amountWithTax"] = $quantity * round($priceWithTax, 2);
                     // If basket comprised any discount, calculate brutto-value for the discount
                     if ($this->sSYSTEM->sUSERGROUPDATA["basketdiscount"] && $this->sCheckForDiscount()) {
                         $discount += ($getArticles[$key]["amountWithTax"] / 100 * $this->sSYSTEM->sUSERGROUPDATA["basketdiscount"]);
@@ -2298,7 +2298,7 @@ class sBasket
                 if (!$this->sSYSTEM->sUSERGROUPDATA["tax"] && $this->sSYSTEM->sUSERGROUPDATA["id"]) {
                     $getArticles[$key]["amountnet"] = $quantity * round($netprice, 2);
                 } else {
-                    $getArticles[$key]["amountnet"] = $quantity * $netprice;
+                    $getArticles[$key]["amountnet"] = $quantity * round($netprice, 2);
                 }
             }
 

--- a/engine/Shopware/Models/Document/Order.php
+++ b/engine/Shopware/Models/Document/Order.php
@@ -511,15 +511,16 @@ class Shopware_Models_Document_Order extends Enlight_Class implements Enlight_Ho
                 $position["netto"] = 0;
             }
 
-            $position["amount_netto"] = round($position["netto"] * $position["quantity"], 2);
+            $position["amount_netto"] = round(round($position["netto"], 2) * $position["quantity"], 2);
 
-            $position["amount"] = round($position["price"] * $position["quantity"], 2);
+            $position["amount"] = round(round($position["price"], 2) * $position["quantity"], 2);
 
             $this->_amountNetto +=  $position["amount_netto"];
             $this->_amount += $position["amount"];
 
             if (!empty($position["tax"])) {
-                $this->_tax[number_format(floatval($position["tax"]), 2)] += round($position["amount"] / ($position["tax"]+100) *$position["tax"], 2);
+                $groupTaxKey = number_format(floatval($position["tax"]), 2);
+                $this->_tax[$groupTaxKey] += round($position["price"] / ($position["tax"]+100) * $position["tax"], 2) * $position["quantity"];
             }
             if ($position["amount"] <= 0) {
                 $this->_discount += $position["amount"];

--- a/engine/Shopware/Models/Order/Order.php
+++ b/engine/Shopware/Models/Order/Order.php
@@ -1066,7 +1066,9 @@ class Order extends ModelEntity
         //iterate order details to recalculate the amount.
         /**@var $detail Detail*/
         foreach ($this->getDetails() as $detail) {
-            $invoiceAmount += $detail->getPrice() * $detail->getQuantity();
+            $roundedPrice = round($detail->getPrice(), 2);
+
+            $invoiceAmount += $roundedPrice * $detail->getQuantity();
 
             $tax = $detail->getTax();
 
@@ -1078,9 +1080,9 @@ class Order extends ModelEntity
             }
 
             if ($this->net) {
-                $invoiceAmountNet += round(($detail->getPrice() * $detail->getQuantity()) / 100 * (100 + $taxValue), 2);
+                $invoiceAmountNet += round($roundedPrice / 100 * (100 + $taxValue), 2) * $detail->getQuantity();
             } else {
-                $invoiceAmountNet += ($detail->getPrice() * $detail->getQuantity()) / (100 + $taxValue) * 100;
+                $invoiceAmountNet += round($roundedPrice / (100 + $taxValue) * 100, 2) * $detail->getQuantity();
             }
         }
 

--- a/tests/Functional/Controllers/Frontend/CheckoutTest.php
+++ b/tests/Functional/Controllers/Frontend/CheckoutTest.php
@@ -76,13 +76,136 @@ class Shopware_Tests_Controllers_Frontend_CheckoutTest extends Enlight_Component
     /**
      * fires the add article request with the given user agent
      * @param $userAgent
+     * @param $quantity
      * @return String | session id
      */
-    private function addBasketArticle($userAgent)
+    private function addBasketArticle($userAgent, $quantity = 1)
     {
         $this->reset();
+        $this->Request()->setParam('sQuantity', $quantity);
         $this->Request()->setHeader('User-Agent', $userAgent);
         $this->dispatch('/checkout/addArticle/sAdd/'.self::ARTICLE_NUMBER);
         return Shopware()->Container()->get('SessionID');
+    }
+
+    /**
+     * Tests that price calculations of the basket do not differ from the price calculation in the invoice document
+     */
+    public function testsBasketCalculationEqualsInvoiceDocumentCalculationNetMode()
+    {
+        $net = true;
+        $this->runTestBasketCalculationEqualsInvoiceDocumentCalculation($net);
+    }
+
+    /**
+     * Tests that price calculations of the basket do not differ from the price calculation in the invoice document
+     */
+    public function testsBasketCalculationEqualsInvoiceDocumentCalculationWithoutNetMode()
+    {
+        $net = false;
+        $this->runTestBasketCalculationEqualsInvoiceDocumentCalculation($net);
+    }
+
+    /**
+     * @param bool $net
+     */
+    public function runTestBasketCalculationEqualsInvoiceDocumentCalculation($net = true)
+    {
+        $tax = $net == true ? 0 : 1;
+
+        // Set net customer group
+        $defaultShop = Shopware()->Models()->getRepository(\Shopware\Models\Shop\Shop::class)->find(1);
+        $previousCustomerGroup = $defaultShop->getCustomerGroup()->getKey();
+        $netCustomerGroup = Shopware()->Models()->getRepository(\Shopware\Models\Customer\Group::class)->findOneBy(['tax' => $tax])->getKey();
+        $this->assertNotEmpty($netCustomerGroup);
+
+        Shopware()->Db()->query(
+            'UPDATE s_user SET customergroup = ? WHERE id = 1',
+            array($netCustomerGroup)
+        );
+
+        // Simulate checkout in frontend
+
+        // Login
+        $this->loginFrontendUser();
+
+        // Add article to basket
+        $this->addBasketArticle(self::USER_AGENT, 5);
+
+        // Confirm checkout
+        $this->reset();
+        $this->Request()->setHeader('User-Agent', self::USER_AGENT);
+        $this->dispatch('/checkout/confirm');
+
+        // Finish checkout
+        $this->reset();
+        $this->Request()->setHeader('User-Agent', self::USER_AGENT);
+        $this->Request()->setParam('sAGB', 'on');
+        $this->dispatch('/checkout/finish');
+
+        // Revert customer group
+        Shopware()->Db()->query(
+            'UPDATE s_user SET customergroup = ? WHERE id = 1',
+            array($previousCustomerGroup)
+        );
+        // Logout frontend user
+        Shopware()->Modules()->Admin()->logout();
+
+        // Fetch created order
+        $orderId = Shopware()->Db()->fetchOne(
+            'SELECT id FROM s_order ORDER BY ID DESC LIMIT 1'
+        );
+        /** @var \Shopware\Models\Order\Order $order */
+        $order = Shopware()->Models()->getRepository(\Shopware\Models\Order\Order::class)->find($orderId);
+
+        // Document/Order calculates amount without shipping costs, we remove them here to be able to compare with the document calculation
+        // This is not true for shippingCostsAsPosition (But this is not the place to test this method anyway)
+        $orderAmount = $order->getInvoiceAmount() - $order->getInvoiceShipping();
+        $orderAmountNet = $order->getInvoiceAmountNet() - $order->getInvoiceShippingNet();
+        $expectedTax = $orderAmount - $orderAmountNet;
+
+        // Access the document via reflection to test the calculation
+        $orderDocument = new Shopware_Models_Document_Order($orderId);
+        $orderDocumentReflection = new \ReflectionObject($orderDocument);
+        $netProperty = $orderDocumentReflection->getProperty('_amountNetto');
+        $netProperty->setAccessible(true);
+        $taxProperty = $orderDocumentReflection->getProperty('_tax');
+        $taxProperty->setAccessible(true);
+        $amountProperty= $orderDocumentReflection->getProperty('_amount');
+        $amountProperty->setAccessible(true);
+
+        $orderDocumentAmount = $amountProperty->getValue($orderDocument);
+        $orderDocumentAmountNet = $netProperty->getValue($orderDocument);
+
+        // Test that sBasket calculation matches calculateInvoiceAmount
+        $this->assertEquals($orderAmount, $orderDocumentAmount, 'amount on invoice');
+        $this->assertEquals($orderAmountNet, $orderDocumentAmountNet, 'net amount on invoice');
+        $this->assertEquals($expectedTax, array_sum($taxProperty->getValue($orderDocument)), 'Tax on invoice');
+    }
+
+    /**
+     * Login as a frontend user
+     * @throws Enlight_Exception
+     * @throws Exception
+     */
+    public function loginFrontendUser()
+    {
+        Shopware()->Front()->setRequest(new Enlight_Controller_Request_RequestHttp());
+        $user = Shopware()->Db()->fetchRow(
+            'SELECT id, email, password, subshopID, language FROM s_user WHERE id = 1'
+        );
+
+        /** @var $repository Shopware\Models\Shop\Repository */
+        $repository = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop');
+        $shop = $repository->getActiveById($user['language']);
+
+        $shop->registerResources();
+
+        Shopware()->Session()->Admin = true;
+        Shopware()->System()->_POST = array(
+            'email' => $user['email'],
+            'passwordMD5' => $user['password'],
+        );
+        Shopware()->Modules()->Admin()->sLogin(true);
     }
 }

--- a/tests/Functional/Controllers/Frontend/CheckoutTest.php
+++ b/tests/Functional/Controllers/Frontend/CheckoutTest.php
@@ -89,6 +89,99 @@ class Shopware_Tests_Controllers_Frontend_CheckoutTest extends Enlight_Component
     }
 
     /**
+     * Tests that price calculations of the basket do not differ from the price calculation in the Order
+     * for customer group
+     */
+    public function testBasketCalculationEqualsOrderCalculateInvoiceAmountInNetMode()
+    {
+        $net = true;
+        $this->runTestBasketCalculationEqualsOrderCalculateInvoiceAmount($net);
+    }
+
+    /**
+     * Tests that price calculations of the basket do not differ from the price calculation in the Order
+     * for customer group
+     */
+    public function testBasketCalculationEqualsOrderCalculateInvoiceAmountWithoutNetMode()
+    {
+        $net = false;
+        $this->runTestBasketCalculationEqualsOrderCalculateInvoiceAmount($net);
+    }
+
+    /**
+     * Compares the calculated price from a basket with the calculated price from Order/Order::calculateInvoiceAmount
+     * It does so by creating via the frontend controllers, and comparing the amount (net & gross) with the values provided by
+     * Order/Order::calculateInvoiceAmount (Which will be called when one changes / saves the order in the backend).
+     *
+     * Also covers a complete checkout process
+     * @param bool $net
+     */
+    public function runTestBasketCalculationEqualsOrderCalculateInvoiceAmount($net = false)
+    {
+        $tax = $net == true ? 0 : 1;
+
+        // Set net customer group
+        $defaultShop = Shopware()->Models()->getRepository(\Shopware\Models\Shop\Shop::class)->find(1);
+        $previousCustomerGroup = $defaultShop->getCustomerGroup()->getKey();
+        $netCustomerGroup = Shopware()->Models()->getRepository(\Shopware\Models\Customer\Group::class)->findOneBy(['tax' => $tax])->getKey();
+        $this->assertNotEmpty($netCustomerGroup);
+        Shopware()->Db()->query(
+            'UPDATE s_user SET customergroup = ? WHERE id = 1',
+            array($netCustomerGroup)
+        );
+
+        // Simulate checkout in frontend
+
+        // Login
+        $this->loginFrontendUser();
+
+        // Add article to basket
+        $this->addBasketArticle(self::USER_AGENT, 5);
+
+        // Confirm checkout
+        $this->reset();
+        $this->Request()->setHeader('User-Agent', self::USER_AGENT);
+        $this->dispatch('/checkout/confirm');
+
+        // Finish checkout
+        $this->reset();
+        $this->Request()->setHeader('User-Agent', self::USER_AGENT);
+        $this->Request()->setParam('sAGB', 'on');
+        $this->dispatch('/checkout/finish');
+
+        // Logout frontend user
+        Shopware()->Modules()->Admin()->logout();
+
+        // Revert customer group
+        Shopware()->Db()->query(
+            'UPDATE s_user SET customergroup = ? WHERE id = 1',
+            array($previousCustomerGroup)
+        );
+
+        // Fetch created order
+        $orderId = Shopware()->Db()->fetchOne(
+            'SELECT id FROM s_order ORDER BY ID DESC LIMIT 1'
+        );
+        /** @var \Shopware\Models\Order\Order $order */
+        $order = Shopware()->Models()->getRepository(\Shopware\Models\Order\Order::class)->find($orderId);
+
+        // Save invoiceAmounts for comparison
+        $previousInvoiceAmount = $order->getInvoiceAmount();
+        $previousInvoiceAmountNet = $order->getInvoiceAmountNet();
+
+        // Simulate backend order save
+        $order->calculateInvoiceAmount();
+
+        // Assert messages
+        $message = 'InvoiceAmount' . ($net ? ' (net shop)' : '') . ': ' . $previousInvoiceAmount .' from sBasket, '. $order->getInvoiceAmount() . ' from getInvoiceAmount';
+        $messageNet = 'InvoiceAmountNet' . ($net ? ' (net shop)' : '') . ': ' . $previousInvoiceAmountNet.' from sBasket, '. $order->getInvoiceAmountNet() . ' from getInvoiceAmountNet';
+
+        // Test that sBasket calculation matches calculateInvoiceAmount
+        $this->assertEquals($order->getInvoiceAmount(), $previousInvoiceAmount, $message);
+        $this->assertEquals($order->getInvoiceAmountNet(), $previousInvoiceAmountNet, $messageNet);
+    }
+
+    /**
      * Tests that price calculations of the basket do not differ from the price calculation in the invoice document
      */
     public function testsBasketCalculationEqualsInvoiceDocumentCalculationNetMode()


### PR DESCRIPTION
## Description
* Why is it necessary?
   * The price calculation is wrong for netto shops.
   * This is a fix for sBasket, the invoice document and Order::calculateInvoiceAmount().
* What does it improve?
   * Fixes the price calculation for netto shops.
   * Adds tests that provide prove that all three components come to the same result when calculating the orders amount, amountNet and tax.
* Does it have side effects?
   * see "BC breaks?"
* What does it **NOT** improve?
   * Some articles / prices will still have rounding issues as described below, **BUT** the tests will make it much easier to track them down, and without the bugs that have been fixed here, the final solution for this "Prices are different everywhere" is much closer.


| Questions        | Answers
| ---------------- | -------------------------------------------------------
| BC breaks?       | yes (If old orders are updated, prices might get corrected)
| Tests pass?      | yes
| Related tickets? | #1064 #847 
| How to test?     | Please describe how to best verify that this PR is correct.


We should all agree that the amounts calculated in sBasket, Order::calculateInvoiceAmount(), and Document/Order::processPositions() should produce equal results, or in short: 
`Basket = Invoice = Update Order Action`

This is roughly true (See PR #1064).


Now, if we take a look at the net mode, which shows all prices within a shop for a customer group as netto amounts.

The total amount with tax included is calculated in the basket.

If you now compare the total amount of a net shop and a normal shop, you might notice they will differ.
To reproduce it buy for example **20xSW10084** in normal mode and then in net mode.
You will notice that the total amounts are off by a few cents.
The higher the amount the higher the error.

# Before the fix
## Example for 10 x SW10084 (The total amount is off by 4ct, tax between gross/net mode differs as well)
### Order in net mode
<img width="715" alt="basket_net_before" src="https://cloud.githubusercontent.com/assets/7721625/24451689/27b30eda-1480-11e7-818d-a6be8e8c1667.png">
<img width="649" alt="invoice_net_before" src="https://cloud.githubusercontent.com/assets/7721625/24451697/2aa2818e-1480-11e7-8744-6f01d00660fc.png">


### Order in normal mode
<img width="715" alt="basket_gross_before" src="https://cloud.githubusercontent.com/assets/7721625/24451704/2ec71cfc-1480-11e7-973b-68417f1ff2ec.png">
<img width="649" alt="invoice_gross_before" src="https://cloud.githubusercontent.com/assets/7721625/24451709/336b7096-1480-11e7-9706-69c8dd7c2858.png">

# After the fix
## Example for 10 x SW10011 (The total amount is now equal)
### Order in net mode
<img width="714" alt="basket_net_after" src="https://cloud.githubusercontent.com/assets/7721625/24451753/5c341320-1480-11e7-8115-edcb4795dd34.png">
<img width="660" alt="invoice_net_after" src="https://cloud.githubusercontent.com/assets/7721625/24451761/5f7bf2fa-1480-11e7-82ee-199fde9b354a.png">


### Order in normal mode
<img width="714" alt="basket_gross_after" src="https://cloud.githubusercontent.com/assets/7721625/24451768/69fceffe-1480-11e7-9fa1-66cd015e007a.png">
<img width="657" alt="invoice_gross_after" src="https://cloud.githubusercontent.com/assets/7721625/24451772/6e6fdf56-1480-11e7-825f-4e39cebb07b4.png">


This behaviour is shared by sBasket, Invoice and `Order::calculateInvoiceAmount()`.

To make the changes required to fix this issue save, and I don’t create inconsistencies between basket, invoice and order save action, I started of with a few tests:

1. b9bfd74a5d0d71b8285a478f06fcc28f563f1ebc Test that Basket = Invoice
2. 10047a34b864ab51110fe84a17453b0e6d8cfcfe Test that Basket = Update Order Action (See PR #1064)

The first two tests make sure that `Basket = Invoice = Update Order Action`

3. 405a0bfdfad0c8a19f2d5ca3e77e2e0ce25b1f49 Test that the total amount (gross and net) are the same for a normal and a net mode shop

The third one actually covers the issue at hand.

This PR is in conflict with #1064 which will be closed in favor of this PR.


## Issues known but not fixed here: (Both require separate PRs, but should be easy to fix after this PR has merged)
  1. Discount's & Shipping Costs might have similar issues.
  2. An issue with first rounding to 3 decimal places and later to two will result in an error of 1ct per article. Effectively this happens: `round(round($price, 3), 2)`
  Example in php: 
```
$price = 16.764705882353;
$newPrice = round($price, 3); // $newPrice = 16,765
$newPrice = round($newPrice, 2); // $newPrice = 16,77
```
  Compared with directly rounding it to two places
```
$price = 16.764705882353;
$newPrice = round($price, 2); // $newPrice = 16,76
```
#### Database example: (last line is how it should be)
<img width="739" alt="bildschirmfoto 2017-03-29 um 11 18 45" src="https://cloud.githubusercontent.com/assets/7721625/24447571/beeab884-1471-11e7-929e-1a8913c35a1c.png">

At least one occurrence of this bug is here: [sArticles.php#L675-L677](https://github.com/shopware/shopware/blob/5.2/engine/Shopware/Core/sArticles.php#L675-L677)
