### PR TITLE
Have the plugin manager reload on fail

### DIFF
--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,0 +1,1 @@
+* Adds missing handling of plugin update fails by reloading the plugin listing in the plugin manager window

--- a/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
+++ b/engine/Shopware/Plugins/Default/Backend/PluginManager/Views/backend/plugin_manager/controller/plugin.js
@@ -471,7 +471,21 @@ Ext.define('Shopware.apps.PluginManager.controller.Plugin', {
                 }, me);
                 callback(response);
             },
-            null,
+            // Error callback
+            function(response) {
+                // If a plugin update fails it will be disabled, however the list will not reload
+                // so that the plugin is listed as activated even though it is disabled.
+
+                // Reload menu to hide disabled menu items and reload the plugin listing so that
+                // plugins are shown in the correct status of activated, disabled or not installed.
+                me.reloadMenu();
+                me.reloadLocalListing();
+
+                // Standard error handling functionality which would be executed if no error
+                // handler was specified.
+                me.displayErrorMessage(response);
+                me.hideLoadingMask();
+            },
             300000
         );
     },


### PR DESCRIPTION
### 1. Why is this change necessary?
When a plugin update fails the local plugin listing is not reloaded. The plugin will therefore still be listed under activated even though it gets disabled due to the failed update.
This can leave users confused since the plugin is listed as active but is not.

### 2. What does this change do, exactly?
It reloads the local plugin listing once a plugin update fails. Furthermore, it reloads the menu to remove disabled menu items.

### 3. Describe each step to reproduce the issue or behaviour.
Create a plugin which fails during the update process. Click update in the plugin manager's local plugin listing.

### 4. Please link to the relevant issues (if any).
None exists.

### 5. Which documentation changes (if any) need to be made because of this PR?
None.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

By the way, I am a new Pickware team member.