### PR TITLE
Add config flag to allow multiple documents of the same type in an order

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -19,6 +19,7 @@ This changelog references changes done in Shopware 5.3 patch versions.
 * Added new API endpoint /users which allows to manage the backend users. For more information, look [here](https://developers.shopware.com/developers-guide/rest-api/api-resource-user/) 
 * Added generatePassword method to engine/Shopware/Components/Random.php which allows to generate cryptographically secure passwords
 * Added UserName and UserEmail validator in /engine/Shopware/Components/Auth
+* Added option to allow multiple documents of the same type for orders in `engine/Shopware/Components/Document.php`.
 
 ### Changes
 

--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -78,6 +78,14 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
     public $_valuesAssigend = false;
 
     /**
+     * Does this document support the creation of multiple documents of the same type instead of overwriting
+     * existing ones?
+     *
+     * @var bool
+     */
+    public $_allowMultipleDocuments = false;
+
+    /**
      * Subshop-Configuration
      *
      * @var array
@@ -199,6 +207,9 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
 
             if (empty($document->_subshop['id'])) {
                 throw new Enlight_Exception("Could not load template path for order $orderID");
+            }
+            if (!empty($config['_allowMultipleDocuments'])) {
+                $document->_allowMultipleDocuments = $config['_allowMultipleDocuments'];
             }
         } else {
             $document->_subshop = Shopware()->Db()->fetchRow("
@@ -579,8 +590,8 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
         SELECT ID,docID,hash FROM s_order_documents WHERE userID = ? AND orderID = ? AND type = ?
         ', [$this->_order->userID, $this->_order->id, $typID]);
 
-        if (!empty($checkForExistingDocument['ID'])) {
-            // Document already exist. Update date and amount!
+        if (!empty($checkForExistingDocument['ID']) && !$this->_allowMultipleDocuments) {
+            // Document already exist, and multiple documents are not allowed. Update date and amount!
             $update = '
             UPDATE `s_order_documents` SET `date` = now(),`amount` = ?
             WHERE `type` = ? AND userID = ? AND orderID = ? LIMIT 1

--- a/tests/Functional/Models/Order/OrderDocumentDocumentTest.php
+++ b/tests/Functional/Models/Order/OrderDocumentDocumentTest.php
@@ -72,4 +72,88 @@ class Shopware_Tests_Models_Order_Document_DocumentTest extends Enlight_Componen
             $this->assertNotNull($document);
         }
     }
+
+    /**
+     * Test the creation of multiple documents of the same order and the same type.
+     * Asserts the number of created documents is 2 if the _allowMultipleDocuments flag is set.
+     */
+    public function testMultipleDocumentsOfTheSameType()
+    {
+        $document1 = Shopware_Components_Document::initDocument(
+            15,
+            1,
+            [
+                '_renderer' => 'pdf',
+                '_preview' => false,
+                '_allowMultipleDocuments' => true,
+            ]
+        );
+        $document1->render();
+
+        $document2 = Shopware_Components_Document::initDocument(
+            15,
+            1,
+            [
+                '_renderer' => 'pdf',
+                '_preview' => false,
+                '_allowMultipleDocuments' => true,
+            ]
+        );
+        $document2->render();
+
+        $documents = Shopware()->Container()->get('models')->getRepository(\Shopware\Models\Order\Document\Document::class)
+            ->findBy([
+                'typeId' => 1,
+                'orderId' => 15,
+            ]);
+        $this->assertCount(2, $documents);
+
+        // Revert changes of this test
+        foreach ($documents as $document) {
+            Shopware()->Container()->get('models')->remove($document);
+        }
+        Shopware()->Container()->get('models')->flush();
+    }
+
+    /**
+     * Test the creation of multiple documents of the same order and the same type.
+     * Asserts the number of created documents stays 1 if the _allowMultipleDocuments flag is not set.
+     */
+    public function testMultipleDocumentsOfTheSameTypeNegative()
+    {
+        $document1 = Shopware_Components_Document::initDocument(
+            15,
+            1,
+            [
+                '_renderer' => 'pdf',
+                '_preview' => false,
+                '_allowMultipleDocuments' => false,
+            ]
+        );
+        $document1->render();
+
+        $document2 = Shopware_Components_Document::initDocument(
+            15,
+            1,
+            [
+                '_renderer' => 'pdf',
+                '_preview' => false,
+                '_allowMultipleDocuments' => false,
+            ]
+        );
+        $document2->render();
+
+        $documents = Shopware()->Container()->get('models')->getRepository(\Shopware\Models\Order\Document\Document::class)
+            ->findBy([
+                'typeId' => 1,
+                'orderId' => 15,
+            ]);
+        $this->assertCount(1, $documents);
+
+        // Revert changes of this test
+        foreach ($documents as $document) {
+            Shopware()->Container()->get('models')->remove($document);
+        }
+        Shopware()->Container()->get('models')->flush();
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

Currently it is not possibly to create multiple documents of the same type for an order. If another document of type X is created, the the first document is simple overwritten, instead of creating an additional one. For example this prevents the creation of partial invoices or partial delivery notes where you need multiple documents of the same type.

### 2. What does this change do, exactly?

This PR adds an optional config field to the Document component that allows the creation of multiple documents for the same type. This is a purely programmatic change and does not have any immediate effect when just using "plain" Shopware via the frontend or backend. It does have a lot of use cases for plugins though, especially together with the pretty new possibility to filter positions on documents (see https://github.com/shopware/shopware/pull/1031).
Currently super ugly hacks are required to achieve multiple documents of the same type for an order, but there is clearly a need for this, as can be seen with this plugin for example: http://store.shopware.com/mbdus41476730029/teildokumente-erstellen.html

### 3. Describe each step to reproduce the issue or behaviour.

Create a document for a certain type for an order. Create another one. The first document will be overwritten, no additional document will be created.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Which documentation changes (if any) need to be made because of this PR?

None, since it just adds an additional option in the PHP code.

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.