### PR TITLE
Fix variable and method name collisions in `Enlight_Hook_HookArgs` and generated hook proxy classes

### DIFF
--- a/engine/Library/Enlight/Hook/HookArgs.php
+++ b/engine/Library/Enlight/Hook/HookArgs.php
@@ -35,31 +35,49 @@
 class Enlight_Hook_HookArgs extends Enlight_Event_EventArgs
 {
     /**
-     * Default getter function to return the class property
-     *
-     * @return mixed
+     * @var mixed
+     */
+    protected $_subject;
+
+    /**
+     * @var string
+     */
+    protected $_method;
+
+    /**
+     * @param mixed $subject
+     * @param string $method
+     * @param array $args
+     */
+    public function __construct($subject, $method, array $args = array())
+    {
+        parent::__construct($args);
+        $this->_subject = $subject;
+        $this->_method = $method;
+    }
+
+    /**
+     * @return mixed The instance which the hook is executed on.
      */
     public function getSubject()
     {
-        return $this->get('class');
+        return $this->_subject;
     }
 
     /**
-     * Default getter function to return the method property
-     * @return mixed
+     * @return string The name of the method whose hooks are being executed.
      */
     public function getMethod()
     {
-        return $this->get('method');
+        return $this->_method;
     }
 
     /**
-     * Default getter function to return the array values of the elements property
-     * @return array
+     * @return array The arguments passed to the hooked method.
      */
     public function getArgs()
     {
-        return array_slice(array_values($this->_elements), 2);
+        return array_values($this->_elements);
     }
 
     /**

--- a/engine/Library/Enlight/Hook/HookExecutionContext.php
+++ b/engine/Library/Enlight/Hook/HookExecutionContext.php
@@ -62,24 +62,18 @@ class Enlight_Hook_HookExecutionContext
 
     /**
      * @param Enlight_Hook_HookManager $hookManager
-     * @param Enlight_Hook_Proxy $class
+     * @param Enlight_Hook_Proxy $subject
      * @param string $method
      * @param array $args
      */
     public function __construct(
         Enlight_Hook_HookManager $hookManager,
-        Enlight_Hook_Proxy $class,
+        Enlight_Hook_Proxy $subject,
         $method,
         array $args
     ) {
         $this->hookManager = $hookManager;
-        $this->args = new Enlight_Hook_HookArgs(array_merge(
-            [
-                'class' => $class,
-                'method' => $method
-            ],
-            $args
-        ));
+        $this->args = new Enlight_Hook_HookArgs($subject, $method, $args);
     }
 
     /*+
@@ -100,7 +94,7 @@ class Enlight_Hook_HookExecutionContext
     {
         // Save this context in the proxy
         $proxy = $this->args->getSubject();
-        $proxy->pushHookExecutionContext($this->args->getMethod(), $this);
+        $proxy->__pushHookExecutionContext($this->args->getMethod(), $this);
 
         // Before hooks
         $this->hookManager->getEventManager()->notify(
@@ -122,7 +116,7 @@ class Enlight_Hook_HookExecutionContext
         );
 
         // Remove this context from the proxy
-        $proxy->popHookExecutionContext($this->args->getMethod());
+        $proxy->__popHookExecutionContext($this->args->getMethod());
 
         return $returnValue;
     }
@@ -144,7 +138,7 @@ class Enlight_Hook_HookExecutionContext
         if (count($listeners) === 0 || $this->parentExecutionLevel >= count($listeners)) {
             // No 'replace' listeners or reached the end of the execution chain, hence execute the original method
             // using a generated helper method. This allows us to call both public and protected methods.
-            $returnValue = $this->args->getSubject()->executeOriginalMethod($this->args->getMethod(), $args);
+            $returnValue = $this->args->getSubject()->__executeOriginalMethod($this->args->getMethod(), $args);
             $this->args->setReturn($returnValue);
 
             return $returnValue;

--- a/engine/Library/Enlight/Hook/HookManager.php
+++ b/engine/Library/Enlight/Hook/HookManager.php
@@ -158,20 +158,20 @@ class Enlight_Hook_HookManager extends Enlight_Class
     }
 
     /**
-     * Creates a new hook execution context using the given $class, $method and $args and executes it. Finally the
+     * Creates a new hook execution context using the given $subject, $method and $args and executes it. Finally the
      * execution result is returned.
      *
-     * @param Enlight_Hook_Proxy $class
+     * @param Enlight_Hook_Proxy $subject
      * @param string $method
      * @param array $args
      * @return mixed
      */
-    public function executeHooks(Enlight_Hook_Proxy $class, $method, array $args)
+    public function executeHooks(Enlight_Hook_Proxy $subject, $method, array $args)
     {
-        $className = get_parent_class($class);
+        $className = get_parent_class($subject);
         $context = new Enlight_Hook_HookExecutionContext(
             $this,
-            $class,
+            $subject,
             $method,
             $args
         );

--- a/engine/Library/Enlight/Hook/Proxy.php
+++ b/engine/Library/Enlight/Hook/Proxy.php
@@ -44,18 +44,24 @@ interface Enlight_Hook_Proxy
      * @param string $method
      * @param Enlight_Hook_HookExecutionContext $context
      */
-    public function pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context);
+    public function __pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context);
 
     /**
      * @param string $method
      */
-    public function popHookExecutionContext($method);
+    public function __popHookExecutionContext($method);
 
     /**
      * @param string $method
      * @return Enlight_Hook_HookExecutionContext
      */
-    public function getCurrentHookProxyExecutionContext($method);
+    public function __getCurrentHookProxyExecutionContext($method);
+
+    /**
+     * @param string $method
+     * @return Enlight_Hook_HookManager
+     */
+    public function __getActiveHookManager($method);
 
     /**
      * @param string $method
@@ -69,5 +75,5 @@ interface Enlight_Hook_Proxy
      * @param array $args
      * @return mixed
      */
-    public function executeOriginalMethod($method, array $args = array());
+    public function __executeOriginalMethod($method, array $args = array());
 }

--- a/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
+++ b/tests/Unit/Components/Hook/EnlightHookProxyFactoryTest.php
@@ -87,7 +87,7 @@ class EnlightHookProxyFactoryTest extends TestCase
 class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Shopware\Tests\Unit\Components\MyBasicTestClass implements \Enlight_Hook_Proxy
 {
 
-    private $_hookProxyExecutionContexts = null;
+    private $__hookProxyExecutionContexts = null;
 
     /**
      * @inheritdoc
@@ -100,32 +100,32 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
     /**
      * @inheritdoc
      */
-    public function pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context)
+    public function __pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context)
     {
-        $this->_hookProxyExecutionContexts[$method][] = $context;
+        $this->__hookProxyExecutionContexts[$method][] = $context;
     }
 
     /**
      * @inheritdoc
      */
-    public function popHookExecutionContext($method)
+    public function __popHookExecutionContext($method)
     {
-        if (isset($this->_hookProxyExecutionContexts[$method])) {
-            array_pop($this->_hookProxyExecutionContexts[$method]);
+        if (isset($this->__hookProxyExecutionContexts[$method])) {
+            array_pop($this->__hookProxyExecutionContexts[$method]);
         }
     }
 
     /**
      * @inheritdoc
      */
-    public function getCurrentHookProxyExecutionContext($method)
+    public function __getCurrentHookProxyExecutionContext($method)
     {
-        if (!isset($this->_hookProxyExecutionContexts[$method]) || count($this->_hookProxyExecutionContexts[$method]) === 0) {
+        if (!isset($this->__hookProxyExecutionContexts[$method]) || count($this->__hookProxyExecutionContexts[$method]) === 0) {
             return null;
         }
 
-        $contextCount = count($this->_hookProxyExecutionContexts[$method]);
-        $context = $this->_hookProxyExecutionContexts[$method][$contextCount - 1];
+        $contextCount = count($this->__hookProxyExecutionContexts[$method]);
+        $context = $this->__hookProxyExecutionContexts[$method][$contextCount - 1];
 
         return $context;
     }
@@ -133,9 +133,20 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
     /**
      * @inheritdoc
      */
+    public function __getActiveHookManager($method)
+    {
+        $context = $this->__getCurrentHookProxyExecutionContext($method);
+        $hookManager = ($context) ? $context->getHookManager() : Shopware()->Hooks();
+
+        return $hookManager;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function executeParent($method, array $args = array())
     {
-        $context = $this->getCurrentHookProxyExecutionContext($method);
+        $context = $this->__getCurrentHookProxyExecutionContext($method);
         if (!$context) {
             throw new Exception(
                 sprintf('Cannot execute parent without hook execution context for method "%s"', $method)
@@ -148,7 +159,7 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
     /**
      * @inheritdoc
      */
-    public function executeOriginalMethod($method, array $args = array())
+    public function __executeOriginalMethod($method, array $args = array())
     {
         return parent::{$method}(...$args);
     }
@@ -158,13 +169,9 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
      */
     public function myPublic($bar, $foo = 'bar', array $barBar = array(), \Shopware\Tests\Unit\Components\MyInterface $fooFoo = null)
     {
-        $method = 'myPublic';
-        $context = $this->getCurrentHookProxyExecutionContext($method);
-        $hookManager = ($context) ? $context->getHookManager() : Shopware()->Hooks();
-
-        return $hookManager->executeHooks(
+        return $this->__getActiveHookManager(__FUNCTION__)->executeHooks(
             $this,
-            $method,
+            __FUNCTION__,
             ['bar' => $bar, 'foo' => $foo, 'barBar' => $barBar, 'fooFoo' => $fooFoo]
         );
     }
@@ -174,13 +181,9 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyBasicTestClassProxy extends \Sh
      */
     protected function myProtected($bar)
     {
-        $method = 'myProtected';
-        $context = $this->getCurrentHookProxyExecutionContext($method);
-        $hookManager = ($context) ? $context->getHookManager() : Shopware()->Hooks();
-
-        return $hookManager->executeHooks(
+        return $this->__getActiveHookManager(__FUNCTION__)->executeHooks(
             $this,
-            $method,
+            __FUNCTION__,
             ['bar' => $bar]
         );
     }
@@ -200,7 +203,7 @@ EOT;
 class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends \Shopware\Tests\Unit\Components\MyReferenceTestClass implements \Enlight_Hook_Proxy
 {
 
-    private $_hookProxyExecutionContexts = null;
+    private $__hookProxyExecutionContexts = null;
 
     /**
      * @inheritdoc
@@ -213,32 +216,32 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends
     /**
      * @inheritdoc
      */
-    public function pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context)
+    public function __pushHookExecutionContext($method, Enlight_Hook_HookExecutionContext $context)
     {
-        $this->_hookProxyExecutionContexts[$method][] = $context;
+        $this->__hookProxyExecutionContexts[$method][] = $context;
     }
 
     /**
      * @inheritdoc
      */
-    public function popHookExecutionContext($method)
+    public function __popHookExecutionContext($method)
     {
-        if (isset($this->_hookProxyExecutionContexts[$method])) {
-            array_pop($this->_hookProxyExecutionContexts[$method]);
+        if (isset($this->__hookProxyExecutionContexts[$method])) {
+            array_pop($this->__hookProxyExecutionContexts[$method]);
         }
     }
 
     /**
      * @inheritdoc
      */
-    public function getCurrentHookProxyExecutionContext($method)
+    public function __getCurrentHookProxyExecutionContext($method)
     {
-        if (!isset($this->_hookProxyExecutionContexts[$method]) || count($this->_hookProxyExecutionContexts[$method]) === 0) {
+        if (!isset($this->__hookProxyExecutionContexts[$method]) || count($this->__hookProxyExecutionContexts[$method]) === 0) {
             return null;
         }
 
-        $contextCount = count($this->_hookProxyExecutionContexts[$method]);
-        $context = $this->_hookProxyExecutionContexts[$method][$contextCount - 1];
+        $contextCount = count($this->__hookProxyExecutionContexts[$method]);
+        $context = $this->__hookProxyExecutionContexts[$method][$contextCount - 1];
 
         return $context;
     }
@@ -246,9 +249,20 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends
     /**
      * @inheritdoc
      */
+    public function __getActiveHookManager($method)
+    {
+        $context = $this->__getCurrentHookProxyExecutionContext($method);
+        $hookManager = ($context) ? $context->getHookManager() : Shopware()->Hooks();
+
+        return $hookManager;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function executeParent($method, array $args = array())
     {
-        $context = $this->getCurrentHookProxyExecutionContext($method);
+        $context = $this->__getCurrentHookProxyExecutionContext($method);
         if (!$context) {
             throw new Exception(
                 sprintf('Cannot execute parent without hook execution context for method "%s"', $method)
@@ -261,7 +275,7 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends
     /**
      * @inheritdoc
      */
-    public function executeOriginalMethod($method, array $args = array())
+    public function __executeOriginalMethod($method, array $args = array())
     {
         return parent::{$method}(...$args);
     }
@@ -271,13 +285,9 @@ class ShopwareTests_ShopwareTestsUnitComponentsMyReferenceTestClassProxy extends
      */
     public function myPublic(&$bar, $foo)
     {
-        $method = 'myPublic';
-        $context = $this->getCurrentHookProxyExecutionContext($method);
-        $hookManager = ($context) ? $context->getHookManager() : Shopware()->Hooks();
-
-        return $hookManager->executeHooks(
+        return $this->__getActiveHookManager(__FUNCTION__)->executeHooks(
             $this,
-            $method,
+            __FUNCTION__,
             ['bar' => &$bar, 'foo' => $foo]
         );
     }

--- a/tests/Unit/Components/Hook/HookManagerTestTarget.php
+++ b/tests/Unit/Components/Hook/HookManagerTestTarget.php
@@ -34,6 +34,7 @@ class HookManagerTestTarget
     const TEST_METHOD_NAME = 'testMethod';
     const RECURSIVE_TEST_METHOD_NAME = 'recursiveTestMethod';
     const PROTECTED_TEST_METHOD_NAME = 'protectedTestMethod';
+    const VARIABLE_NAME_COLLISION_TEST_METHOD_NAME = 'variableNameCollisionTestMethod';
 
     public $originalMethodCallCounter = 0;
     public $originalRecursiveMethodCallCounter = 0;
@@ -62,5 +63,10 @@ class HookManagerTestTarget
         $this->originalProtectedMethodCallCounter++;
 
         return $name;
+    }
+
+    public function variableNameCollisionTestMethod($class, $method, $context, $hookManager)
+    {
+        return $class . $method . $context . $hookManager;
     }
 }


### PR DESCRIPTION
**Note: This PR fixes a critical bug that was introduced in c4b22d8bed975713c99160550beaeb17b8311bbb.** Even though it was only merged into the `5.5` branch and hence was not released yet, this PR should be treated with high priority.

### 1. Why is this change necessary?

Currently using any of the following argument names when declaring methods that are made hookable by implementing the `Enlight_Hook` interface in the respective class result in various errors:

* `$method`
* `$context`
* `$hookManager`
* `$class`

The values of any arguments using one of these names would be either overwritten by the generated proxy class or overwrite all or parts of the context required to execute the hook correctly. Consider this simple class:

```php
class MyHookableClass implements \Enlight_Hook
{
    public function hookableMethod($context, $hookManager)
    {
        echo get_class($context) . "\n";
        echo get_class($hookManager) . "\n";
    }
}
```

When adding a hook to `MyHookableClass::hookableMethod()` and calling it, e.g. `$instance->hookableMethod(new \DateTime(), new \DateTime())`, the values of `$context` and `$hookManager` are overwritten before the method or any hook is called. Hence the output is

```
Enlight_Hook_HookExecutionContext
Enlight_Hook_HookManager
```

instead of the expected

```
DateTime
DateTime
```

Having a hookable method that uses the argument names `$class` and/or `$method` even results in a fatal error, because they corrupt the created `Enlight_Hook_HookArgs`:

```php
class MySecondHookableClass implements \Enlight_Hook
{
    public function hookableMethod($class, $method)
    {
    }
}
```

When adding a hook to `MySecondHookableClass::hookableMethod()` and calling it, e.g. `$instance->hookableMethod('class', 'method')`, we get a fatal error:

```
PHP Fatal error:  Uncaught Error: Call to a member function __pushHookExecutionContext() on string
```

Furthermore the following method names can effectively not be delcared by classes implementing `Enlight_Hook`, because that interface _reserves_ their usage for purposes internal to the hook execution and the generated proxy class just overrides any original implementation (without calling the `parent`):

* `getHookMethods()`
* `executeParent()`
* `pushHookExecutionContext()`
* `popHookExecutionContext()`
* `getCurrentHookProxyExecutionContext()`
* `getActiveHookManager()`
* `executeOriginalMethod()`

The first two methods `getHookMethods()` and `executeParent()` have always been declared in `Enlight_Hook`, the other five methods were added to the interface by #1501 (via c4b22d8bed975713c99160550beaeb17b8311bbb). This behaviour adds constraints on how a hookable class can be implemented, by preventing the class from declaring methods using the listed names.

The following write up explains the different problems in detail.

#### 1.1. `$method`, `$context` and `$hookManager` and _reserved_ methods

In #1501 I rewrote the execution of hooked methods to add a predictable execution model of `replace` hooks. A generated proxy class extends the original class and overrides all hooked methods. Additional helper methods defined in `Enlight_Hook_Proxy` are added to the proxy class to make the execution and tracking of the hook possible. This creates two problems:

* When overriding a hooked method, the new implementation declares three helper variables `$method`, `$context` and `$hookManager` before calling `executeHook()` on the latter:

    https://github.com/VIISON/shopware/blob/b59e9ef936d3aee47fbb4281a82ef9aecea03001/engine/Library/Enlight/Hook/ProxyFactory.php#L354-L362

    If any of the method arguments use any of the names `$method`, `$context` and `$hookManager`, their values will be overwritten before being used to execute the overridden method. **This is actually a critical bug that was introduced in c4b22d8bed975713c99160550beaeb17b8311bbb and needs fixing before release.**

* Adding helper methods to the proxy class _reserves_ their names and effectively prevents any hookable classes from using those method names themselves, because the original implementation will always be overridden. Its highly unlikely that the new method names added to the `Enlight_Hook_Proxy` interface will ever by used by a hookable class. However, the hook system should not dictate which method names can be used in a hookable class and which don't.

#### 1.2. `$class` (and `$method`, again)

While investigating the described behvaiour, I found that the argument names `$class` and `$method` have actually never worked correctly since the existence of hook proxies in Shopware. That is due to how `Enlight_Hook_HookArgs` handles the special arguments `'class'` (the hook subject, i.e. the instance of a hooked class which the hooks are being executed on) and `'method'` (the name of the hooked method whose hooks are being executed).

Prior to this PR, the inherited constructor of `Enlight_Hook_HookArgs` expected a single array containing both the _subject_ and _method_ of the hook execution as well as all method arguments that were passed to the hooked method, all wrapped in a single associative array:

https://github.com/VIISON/shopware/blob/b59e9ef936d3aee47fbb4281a82ef9aecea03001/engine/Library/Enlight/Event/EventArgs.php#L52-L61

When creating the hook args, _subject_ and _method_ were added to an array using the keys `'class'` and `'method'`, respectively. That array was then merged with the associative array containing all method arguments using `array_merge()`:

https://github.com/VIISON/shopware/blob/b59e9ef936d3aee47fbb4281a82ef9aecea03001/engine/Library/Enlight/Hook/HookExecutionContext.php#L76-L82

Internally `Enlight_Hook_HookArgs` then used the special keys `'class'` and `'method'` when calling `Enlight_Hook_HookArgs::getSubject()` or `Enlight_Hook_HookArgs::getMethod()` to the return the hook subject or method, respectively:

https://github.com/VIISON/shopware/blob/b59e9ef936d3aee47fbb4281a82ef9aecea03001/engine/Library/Enlight/Hook/HookArgs.php#L37-L54

To prevent these two special arguments from being returned when calling `Enlight_Hook_HookArgs::getArgs()`, the first two elements of the internal `_elements` were sliced off (associative PHP arrays are still _ordered_ by the order in which the elements were added):

https://github.com/VIISON/shopware/blob/b59e9ef936d3aee47fbb4281a82ef9aecea03001/engine/Library/Enlight/Hook/HookArgs.php#L56-L63

All this becomes a problem as soon as any definition of a hookable method uses the argument names `$class` and/or `$method`. When generating the respective proxy class, the method arguments are collected and wrapped in an associative array, using the argument names as keys for the respective argument values. Merging such an arguments array on to the array containing the special `'class'` and `'method'` elements overwrites the existing values of `'class'` and/or `'method'`. For example:

```php
<?php
class MyHookedClass
{
    public function anyHookedMethod($class, $method, $someOtherArgument)
    {
    }
}

$specialVariables = [
    'class' => new MyHookedClass(),
    'method' => 'anyHookedMethod',
];
$methodArgs = [
    'class' => '5A',
    'method' => 'strtolower',
    'someOtherArgument' => 'whatever',
];

$mergedArgs = array_merge($specialVariables, $methodArgs);
var_dump($mergedArgs);
```

Output:
```
array(3) {
    'class' =>
    string(2) "5A"
    'method' =>
    string(10) "strtolower"
    'someOtherArgument' =>
    string(8) "whatever"
}
```

Both the values of `'class'` and `'method'` were overwritten by the values passed to the hooked methods. Hence the whole hook execution context is gone and calling `getSubject()` or `getMethod()` on the hook args now return `5A` and `strtolower`, respectively.

The fact that this breaks the exection of the hook and results in a fatal error is probably the reason why no hookable method has ever used `$class` nor `$method` as argument names. However, just like described in _1.1._, a generated proxy class should not impose any limitations on how the hookable class is designed.

### 2. What does this change do, exactly?

This PR fixes all issues described in _1._ by changing the following:

* 1.1. Name collisions:
    - The generated implementation of overridden, hooked methods in the proxy class is changed to not declare/overwrite any variables.
    - All methods added to the `Enlight_Hook_Proxy` interface by PR #1501 (c4b22d8bed975713c99160550beaeb17b8311bbb) are prefixed with `__` to prevent collisions with original method of the extended, hookable classes.
    - All property names of the generated proxy class are prefixed with `__` to prevent collisions with original properties of the extended, hookable class.
* 1.2. _Special_ hook args:
    - `Enlight_Hook_HookArgs` now has two dedicated properties `$_subject` and `$_method` for the values previously stored in the special `'class'` and `'method'` args, respectively, instead of in the args (**partly breaking**).

**Please note that the changes necessary to fix _1.2._ are partly breaking**, because it is no longer possible to get the hook subject by calling `$args->get('class')` or the hooked method's name by calling `$args->get('method')`. However, the existing methods `Enlight_Hook_HookArgs::getSubject()` and `Enlight_Hook_HookArgs::getMethod()` still work as before. Hence I consider this as _partly_ breaking, because IMO the correct way to retrieve the subject or method has always been to call the dedicated methods. When calling `Enlight_Hook_HookArgs::get()` the intention should have always been to get an argument that was passed to the hooked method.

### 3. Describe each step to reproduce the issue or behaviour.

* 1.1 Name collisions:
    - Create a hookable class and implement a `public` method using one or more of the argument names `$method`, `$context` and `$hookManager`. Try to call the method on a class instance (it must be instantiated by `Enlight_Class` to get the hook proxy) and check the arguments passed to the original method.
    - Create a hookable class and implement method using one of the names reserved by `Enlight_Hook_Proxy`, e.g. `executeOriginalMethod()`. Try to call the method on a class instance (it must be instantiated by `Enlight_Class` to get the hook proxy).
* 1.2. _Special_ hook args:
    - Create a hookable class and implement a `public` method using one or both of the argument names `$class` and `$method`. Try to call the method on a class instance (it must be instantiated by `Enlight_Class` to get the hook proxy). This should result in a fatal error.

### 4. Please link to the relevant ~~issues~~ pull requests (if any).

* Fix execution model of `replace` hooks (#1501)

### 5. Which documentation changes (if any) need to be made because of this PR?

n/a

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
