### PR TITLE
Add event to filter generated HTML of \Shopware_Components_Document

### DIFF
--- a/engine/Shopware/Components/Document.php
+++ b/engine/Shopware/Components/Document.php
@@ -249,10 +249,16 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             $this->_template->setTemplateDir($inheritance);
         }
 
-        $data = $this->_template->fetch('documents/' . $this->_document['template'], $this->_view);
+        $html = $this->_template->fetch('documents/' . $this->_document['template'], $this->_view);
+
+        /** @var \Enlight_Event_EventManager $eventManager */
+        $eventManager = Shopware()->Container()->get('events');
+        $html = $eventManager->filter('Shopware_Components_Document_Render_FilterHtml', $html, [
+            'subject' => $this,
+        ]);
 
         if ($this->_renderer === 'html' || !$this->_renderer) {
-            echo $data;
+            echo $html;
         } elseif ($this->_renderer === 'pdf') {
             $mpdfConfig = array_replace_recursive(
                 Shopware()->Container()->getParameter('shopware.mpdf.defaultConfig'),
@@ -265,14 +271,14 @@ class Shopware_Components_Document extends Enlight_Class implements Enlight_Hook
             );
             if ($this->_preview == true || !$this->_documentHash) {
                 $mpdf = new \Mpdf\Mpdf($mpdfConfig);
-                $mpdf->WriteHTML($data);
+                $mpdf->WriteHTML($html);
                 $mpdf->Output();
                 exit;
             }
             $documentsPath = rtrim(Shopware()->Container()->getParameter('shopware.app.documentsdir'), '/');
             $path = $documentsPath . '/' . $this->_documentHash . '.pdf';
             $mpdf = new \Mpdf\Mpdf($mpdfConfig);
-            $mpdf->WriteHTML($data);
+            $mpdf->WriteHTML($html);
             $mpdf->Output($path, 'F');
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently the generated HTML code for document cannot be manipulated before it is put in the PDF renderer. That's why some plugins use replace-hooks for the method `\Shopware_Components_Document::render` to manipulate the HTML.
Replace hooks should be avoided in any case because multiple replace hooks of the same method lead to unexpected results in Shopware (doubled executions).

### 2. What does this change do, exactly?
Adds a filter event `Shopware_Components_Document_Render_FilterHtml` to allow manipulation of the generated document HTML before rendering it to PDF.

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?
N/A

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.