### PR TITLE
Show wrong OPCache settings in system info

### DIFF
--- a/UPGRADE-5.5.md
+++ b/UPGRADE-5.5.md
@@ -11,6 +11,7 @@ This changelog references changes done in Shopware 5.5 patch versions.
 * Added new config `alwaysShowMainFeatures` to show the template from `mainfeatures` in the whole checkout process
 * Added configuration for displaying shipping costs pre calculation in off canvas shopping cart
 * Added wrapping smarty blocks to Themes/Frontend/Bare/documents/index.tpl
+* Added OPCache options `opcache.use_cwd` and `opcache.validate_root` to the system info's requirements tab.
 
 ### Changes
 

--- a/engine/Shopware/Components/Check/Requirements.php
+++ b/engine/Shopware/Components/Check/Requirements.php
@@ -68,6 +68,7 @@ class Requirements
             'checks' => [],
         ];
 
+        $checks = [];
         foreach ($this->runChecks() as $requirement) {
             $check = [];
             $check['name'] = (string) $requirement->name;
@@ -79,6 +80,12 @@ class Requirements
             $check['result'] = (bool) $requirement->result;
             $check['error'] = (bool) $requirement->error;
 
+            $checks[] = $check;
+        }
+
+        $checks = array_merge($checks, $this->checkOpcache());
+
+        foreach ($checks as $check) {
             if (!$check['check'] && $check['error']) {
                 $check['status'] = 'error';
                 $result['hasErrors'] = true;
@@ -237,6 +244,42 @@ class Requirements
         }
 
         return $v;
+    }
+
+    /**
+     * Checks the opcache configuration if the opcache exists.
+     */
+    private function checkOpcache()
+    {
+        if (!extension_loaded('Zend OPcache')) {
+            return [];
+        }
+
+        $useCwdOption = $this->compare('opcache.use_cwd', ini_get('opcache.use_cwd'), 1);
+        $useCwdRequirement = [
+            'name' => 'opcache.use_cwd',
+            'group' => 'core',
+            'required' => 1,
+            'version' => ini_get('opcache.use_cwd'),
+            'result' => ini_get('opcache.use_cwd'),
+            'notice' => '',
+            'check' => $this->compare('opcache.use_cwd', ini_get('opcache.use_cwd'), 1),
+            'error' => '',
+        ];
+
+        $validateRootOption = $this->compare('opcache.validate_root', ini_get('opcache.validate_root'), 1);
+        $validateRootRequirement = [
+            'name' => 'opcache.validate_root',
+            'group' => 'core',
+            'required' => 1,
+            'version' => ini_get('opcache.validate_root'),
+            'result' => ini_get('opcache.validate_root'),
+            'notice' => '',
+            'check' => $this->compare('opcache.validate_root', ini_get('opcache.validate_root'), 1),
+            'error' => '',
+        ];
+
+        return [$useCwdRequirement, $validateRootRequirement];
     }
 
     /**

--- a/recovery/install/src/Requirements.php
+++ b/recovery/install/src/Requirements.php
@@ -61,6 +61,7 @@ class Requirements
             'checks' => [],
         ];
 
+        $checks = [];
         foreach ($this->runChecks() as $requirement) {
             $check = [];
 
@@ -77,6 +78,12 @@ class Requirements
             $check['check'] = (bool) (string) $requirement->result;
             $check['error'] = (bool) $requirement->error;
 
+            $checks[] = $check;
+        }
+
+        $checks = array_merge($checks, $this->checkOpcache());
+
+        foreach ($checks as $check) {
             if (!$check['check'] && $check['error']) {
                 $check['status'] = 'error';
                 $result['hasErrors'] = true;
@@ -197,6 +204,42 @@ class Requirements
     private function checkModRewrite()
     {
         return isset($_SERVER['MOD_REWRITE']);
+    }
+
+    /**
+     * Checks the opcache configuration if the opcache exists.
+     */
+    private function checkOpcache()
+    {
+        if (!extension_loaded('Zend OPcache')) {
+            return [];
+        }
+
+        $useCwdOption = $this->compare('opcache.use_cwd', ini_get('opcache.use_cwd'), 1);
+        $useCwdRequirement = [
+            'name' => 'opcache.use_cwd',
+            'group' => 'core',
+            'required' => 1,
+            'version' => ini_get('opcache.use_cwd'),
+            'result' => ini_get('opcache.use_cwd'),
+            'notice' => '',
+            'check' => $this->compare('opcache.use_cwd', ini_get('opcache.use_cwd'), 1),
+            'error' => '',
+        ];
+
+        $validateRootOption = $this->compare('opcache.validate_root', ini_get('opcache.validate_root'), 1);
+        $validateRootRequirement = [
+            'name' => 'opcache.validate_root',
+            'group' => 'core',
+            'required' => 1,
+            'version' => ini_get('opcache.validate_root'),
+            'result' => ini_get('opcache.validate_root'),
+            'notice' => '',
+            'check' => $this->compare('opcache.validate_root', ini_get('opcache.validate_root'), 1),
+            'error' => '',
+        ];
+
+        return [$useCwdRequirement, $validateRootRequirement];
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
If two Shopware shops are running on the same server, they might override each others model definition, if the OPCache module is not configured correctly. Depending on the definition, OPCache does not include the directory path in its caching which can lead to multiple files with the same name overriding each other. As a result, the shop will experience sporadic model definition errors which are hard to track down.

This pr will add the critical OPCache settings into the requirements tab, if the OPCache module is enabled.

### 2. What does this change do, exactly?
This change adds the `opcache.use_cwd = 1` and the `opcache.validate_root = 1` settings into the requirements tab in case OPCache is used.

### 3. Describe each step to reproduce the issue or behaviour.
Configure OPCache incorrectly with `opcache.use_cwd = 0` and `opcache.validate_root = 0`. The requirements tab will now show if the correct settings are defined.

### 4. Please link to the relevant issues (if any).
None

### 5. Which documentation changes (if any) need to be made because of this PR?
Add the options into the sysadmins guide: https://developers.shopware.com/sysadmins-guide/shopware-5-performance-for-sysadmins/#opcode-cache

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.