### PR TITLE
Fix setOneToMany on model entities

### DIFF
--- a/engine/Shopware/Components/Model/ModelEntity.php
+++ b/engine/Shopware/Components/Model/ModelEntity.php
@@ -169,10 +169,10 @@ abstract class ModelEntity
      * <li>So the parameter expect <b>"customer"</b></li>
      * </ul>
      *
-     * @param array[]|ModelEntity[]|null $data      Model data, example: an array of \Shopware\Models\Order\Order
-     * @param string                     $model     Full namespace of the association model, example: '\Shopware\Models\Order\Order'
-     * @param string                     $property  Name of the association property, example: 'orders'
-     * @param string                     $reference Name of the reference property, example: 'customer'
+     * @param array[]|ModelEntity[]|iterable|null $data      Model data, example: an array of \Shopware\Models\Order\Order
+     * @param string                              $model     Full namespace of the association model, example: '\Shopware\Models\Order\Order'
+     * @param string                              $property  Name of the association property, example: 'orders'
+     * @param string                              $reference Name of the reference property, example: 'customer'
      *
      * @return $this
      */
@@ -190,8 +190,8 @@ abstract class ModelEntity
 
             return $this;
         }
-        // If no array passed or if false passed, return
-        if (!is_array($data)) {
+        // If no iterable passed or if false passed, return
+        if (!is_iterable($data)) {
             return $this;
         }
 

--- a/engine/Shopware/Models/Country/Area.php
+++ b/engine/Shopware/Models/Country/Area.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Models\Country;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
@@ -66,6 +67,11 @@ class Area extends ModelEntity
      * @ORM\Column(name="active", type="integer", nullable=true)
      */
     private $active = null;
+
+    public function __construct()
+    {
+        $this->countries = new ArrayCollection();
+    }
 
     /**
      * @return int

--- a/engine/Shopware/Models/Document/Document.php
+++ b/engine/Shopware/Models/Document/Document.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Models\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
@@ -139,6 +140,11 @@ class Document extends ModelEntity
      * @ORM\JoinColumn(name="id", referencedColumnName="documentID")
      */
     private $elements;
+
+    public function __construct()
+    {
+        $this->elements = new ArrayCollection();
+    }
 
     /**
      * Getter function for the unique id identifier property

--- a/engine/Shopware/Models/Voucher/Voucher.php
+++ b/engine/Shopware/Models/Voucher/Voucher.php
@@ -24,6 +24,7 @@
 
 namespace Shopware\Models\Voucher;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
@@ -194,6 +195,11 @@ class Voucher extends ModelEntity
      * @ORM\Column(name="customer_stream_ids", type="text", nullable=true)
      */
     private $customerStreamIds;
+
+    public function __construct()
+    {
+        $this->codes = new ArrayCollection();
+    }
 
     /**
      * Getter Method to get the Id field from the Model

--- a/tests/Unit/Components/Model/ModelEntityTest.php
+++ b/tests/Unit/Components/Model/ModelEntityTest.php
@@ -24,12 +24,16 @@
 
 namespace Shopware\Tests\Unit\Components\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Models\Article\Article;
 use Shopware\Models\Article\Configurator\Template\Template;
 use Shopware\Models\Article\Link;
 use Shopware\Models\Article\Supplier;
+use Shopware\Models\Country\Area;
+use Shopware\Models\Document\Document;
 use Shopware\Models\Tax\Tax;
+use Shopware\Models\Voucher\Voucher;
 
 /**
  * @covers \Shopware\Components\Model\ModelEntity
@@ -474,6 +478,81 @@ class ModelEntityTest extends TestCase
         static::assertNotContains($link0, $article->getLinks());
 
         static::assertEquals('batz', $article->getLinks()->first()->getName());
+    }
+
+    public function testCanSetElementsOnDocument()
+    {
+        $document = new Document();
+
+        $data = [
+            [
+                'name' => 'dummy',
+            ],
+        ];
+        $document->setElements($data);
+
+        static::assertCount(1, $document->getElements());
+        static::assertEquals('dummy', $document->getElements()->first()->getName());
+    }
+
+    public function testCanSetElementsOnDocumentWithArrayCollection()
+    {
+        $document = new Document();
+
+        $data = new ArrayCollection([
+            [
+                'name' => 'dummy',
+            ],
+        ]);
+        $document->setElements($data);
+
+        static::assertCount(1, $document->getElements());
+        static::assertEquals('dummy', $document->getElements()->first()->getName());
+    }
+
+    public function testCanSetCodesOnVoucher()
+    {
+        $voucher = new Voucher();
+
+        $data = [
+            [
+                'code' => 'dummy',
+            ],
+        ];
+        $voucher->setCodes($data);
+
+        static::assertCount(1, $voucher->getCodes());
+        static::assertEquals('dummy', $voucher->getCodes()->first()->getCode());
+    }
+
+    public function testCanSetCodesOnVoucherWithArrayCollection()
+    {
+        $voucher = new Voucher();
+
+        $data = new ArrayCollection([
+            [
+                'code' => 'dummy',
+            ],
+        ]);
+        $voucher->setCodes($data);
+
+        static::assertCount(1, $voucher->getCodes());
+        static::assertEquals('dummy', $voucher->getCodes()->first()->getCode());
+    }
+
+    public function testCanSetCountriesOnArea()
+    {
+        $area = new Area();
+
+        $data = [
+            [
+                'name' => 'dummy',
+            ],
+        ];
+        $area->setCountries($data);
+
+        static::assertCount(1, $area->getCountries());
+        static::assertEquals('dummy', $area->getCountries()->first()->getName());
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Currently some model entities using `setOneToMany` to set a `Collection` property do not initialize these properties and thus `setOneToMany` can throw an exception. Furthermore `setOneToMany` currently does not handle `Collection` as an argument, which breaks the defined typehint.

### 2. What does this change do, exactly?
This change adds a constructor to model entities with uninitialized `Collection` properties which use  `setOneToMany` in their setter and allows `Collection`'s to be used as an argument for `setOneToMany`.

### 3. Describe each step to reproduce the issue or behavior.

https://github.com/VIISON/shopware/blob/3c7c03db4d6474b45e0a0e763a33d6704bd5c480/tests/Unit/Components/Model/ModelEntityTest.php#L488-L495

https://github.com/VIISON/shopware/blob/546d56d7c236ad40b6ad8058ddb9f376100f1371/tests/Unit/Components/Model/ModelEntityTest.php#L503-L510

### 4. Please link to the relevant issues (if any).
n/a

### 5. Which documentation changes (if any) need to be made because of this PR?
n/a

### 6. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.